### PR TITLE
Minor fix for windows

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -22,7 +22,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_program( CYTHON_EXECUTABLE NAMES cython )
+find_program( CYTHON_EXECUTABLE NAMES cython cython.bat )
 
 include( FindPackageHandleStandardArgs )
 FIND_PACKAGE_HANDLE_STANDARD_ARGS( Cython REQUIRED_VARS CYTHON_EXECUTABLE )


### PR DESCRIPTION
Anaconda (at least) uses cython.bat as the main CLI entry point cython.
