### PR TITLE
Update FindCython.cmake to find cython3

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -33,7 +33,7 @@ if( PYTHONINTERP_FOUND )
     )
 else()
   find_program( CYTHON_EXECUTABLE
-    NAMES cython cython.bat
+    NAMES cython cython.bat cython3
     )
 endif()
 


### PR DESCRIPTION
Ubuntu 13.10 now have a cython3 executable for use with Python3 (http://packages.ubuntu.com/fr/raring/cython3)
