### PR TITLE
Add missing cython3 detection

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -28,7 +28,7 @@ find_package( PythonInterp )
 if( PYTHONINTERP_FOUND )
   get_filename_component( _python_path ${PYTHON_EXECUTABLE} PATH )
   find_program( CYTHON_EXECUTABLE
-    NAMES cython cython.bat
+    NAMES cython cython.bat cython3
     HINTS ${_python_path}
     )
 else()


### PR DESCRIPTION
Hi,

It looks like have submitted #11 a little too quickly yesterday, I forgot to add cython3 detection when PYTHONINTERP_FOUND is TRUE. My apologies.
