### PR TITLE
Update rectangle_props.py

### DIFF
--- a/bin/rectangle_props.py
+++ b/bin/rectangle_props.py
@@ -1,6 +1,6 @@
 import sys
 
-from rectangle import Rectangle
+from rect import Rectangle
 
 def main(x0, y0, x1, y1):
     rect = Rectangle(int(x0), int(y0), int(x1), int(y1))


### PR DESCRIPTION
The module name is "rect", not "rectangle". This caused some confusion as I thought the build system was not working; indeed it works fine, just was trying to import something that didn't exist!
